### PR TITLE
Solaris' hstrerror lives in libresolv, not libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,9 @@ AC_CHECK_HEADERS(sys/uio.h)
 AC_CHECK_HEADERS(unistd.h)
 AC_CHECK_HEADERS(winsock.h)
 
+# Check libresolv on solaris
+AC_SEARCH_LIBS([hstrerror], [resolv], [], [AC_MSG_FAILURE([hstrerror was not found on your system])], [-lsocket -lnsl])
+
 PKG_PROG_PKG_CONFIG
 if test -n "$PKG_CONFIG"; then
     # Horrible hack for systems where the pkg-config install directory is simply wrong!


### PR DESCRIPTION
This doesn't build on Solaris, as it needs to link against libresolv to call hstrerror(3).
