### PR TITLE
data-buffer.h should be installed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,10 +37,8 @@ LIBPROTOBUF_C_RPC_AGE=0
 lib_LTLIBRARIES += \
 	protobuf-c-rpc/libprotobuf-c-rpc.la
 
-noinst_HEADERS = \
-	protobuf-c-rpc/protobuf-c-rpc-data-buffer.h
-
 nobase_include_HEADERS += \
+	protobuf-c-rpc/protobuf-c-rpc-data-buffer.h \
 	protobuf-c-rpc/protobuf-c-rpc-dispatch.h \
 	protobuf-c-rpc/protobuf-c-rpc.h
 


### PR DESCRIPTION
since 5aa3c42ec6165c673aa2a6f755675ff58b7026d3, protobuf-c-rpc-data-buffer.h should be installed.