### PR TITLE
Build for WIN32 with MSVC 2008

### DIFF
--- a/protobuf-c-rpc/protobuf-c-rpc-data-buffer.h
+++ b/protobuf-c-rpc/protobuf-c-rpc-data-buffer.h
@@ -116,12 +116,12 @@ size_t   protobuf_c_rpc_data_buffer_transfer            (ProtobufCRPCDataBuffer 
 
 /* file-descriptor mucking */
 int      protobuf_c_rpc_data_buffer_writev              (ProtobufCRPCDataBuffer       *read_from,
-                                         int              fd);
+                                         ProtobufC_RPC_FD              fd);
 int      protobuf_c_rpc_data_buffer_writev_len          (ProtobufCRPCDataBuffer       *read_from,
-                                         int              fd,
+                                         ProtobufC_RPC_FD              fd,
 					 size_t           max_bytes);
 int      protobuf_c_rpc_data_buffer_read_in_fd          (ProtobufCRPCDataBuffer       *write_to,
-                                         int              read_from);
+                                         ProtobufC_RPC_FD              read_from);
 
 /* This deallocates memory used by the buffer-- you are responsible
  * for the allocation and deallocation of the ProtobufCRPCDataBuffer itself. */

--- a/protobuf-c-rpc/protobuf-c-rpc.h
+++ b/protobuf-c-rpc/protobuf-c-rpc.h
@@ -36,7 +36,9 @@
 
 typedef enum
 {
+#ifndef WIN32
   PROTOBUF_C_RPC_ADDRESS_LOCAL,  /* unix-domain socket */
+#endif
   PROTOBUF_C_RPC_ADDRESS_TCP     /* host/port tcp socket */
 } ProtobufC_RPC_AddressType;
 
@@ -203,9 +205,12 @@ typedef protobuf_c_boolean
           (*ProtobufC_RPC_IsRpcThreadFunc) (ProtobufC_RPC_Server *server,
                                             ProtobufCRPCDispatch    *dispatch,
                                             void                 *is_rpc_data);
+
+#ifndef WIN32
 void protobuf_c_rpc_server_configure_threading (ProtobufC_RPC_Server *server,
                                                 ProtobufC_RPC_IsRpcThreadFunc func,
                                                 void          *is_rpc_data);
+#endif
 
 
 /* Error handling */


### PR DESCRIPTION
To compile for Visual C / WIN32 the following changes were required:

(multiple files)
+ inline was defined as __inline
+ variable declarations were moved to the beginning of scope blocks.
+ partially expanded GSK_LIST_* macros.  (macros are expanded differently
  under Visual C than they are udner gcc).
+ Removed support for PROTOBUF_C_RPC_ADDRESS_LOCAL; it depends on AF_UNIX.
+ Removed support for protobuf_c_rpc_server_configure_threading;
  it depends on pipe().  Windows has pipe support (using CreatePipe) but
  has different semantics.

protobuf-c-rpc-dispatch.c
+ Replaced FDMap sparsed array with sorted array of FDMap.
+ Replaced timer tree with a sorted linked list.
  Neither of these changes are quite as efficient as how the code was
  previously; however the number of FDs or timers would have to be very
  large to see a performance impact.
  Because macro expansion works differently in VC than gcc, the red-black
  tree code is impossible to compile, even attempting to partially
  expand the initial macros.

To compile for Windows CE:
+ errno defined to WSAGetLastError()
+ strerror implemented using FormatMessage.
+ non-polling (select) based dispatch model implemented.

Signed-off-by: Mark Salisbury <mark.salisbury@hp.com>