### PR TITLE
broken header multiple include protection

### DIFF
--- a/example/simplerpc/simplerpc.h
+++ b/example/simplerpc/simplerpc.h
@@ -1,5 +1,5 @@
 #ifndef __PROTOBUF_SIMPLERPC_H_
-#ifndef __PROTOBUF_SIMPLERPC_H_
+#define __PROTOBUF_SIMPLERPC_H_ 1
 
 #include <protobuf-c/protobuf-c.h>
 


### PR DESCRIPTION
fixed #ifndef twice instead of defining __PROTOBUF_SIMPLERPC_H_ after checking that it is not defined